### PR TITLE
Improve namespace controller

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -20,6 +20,13 @@ class RouteServiceProvider extends ServiceProvider
     public const HOME = '/home';
 
     /**
+     * The controller namespace for the application.
+     *
+     * @var string|null
+     */
+    protected $namespace = 'App\\Http\\Controllers';
+
+    /**
      * Define your route model bindings, pattern filters, etc.
      *
      * @return void

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,68 +13,66 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-$controller_path = 'App\Http\Controllers';
-
 // Main Page Route
-Route::get('/', $controller_path . '\dashboard\Analytics@index')->name('dashboard-analytics');
+Route::get('/', 'dashboard\Analytics@index')->name('dashboard-analytics');
 
 // layout
-Route::get('/layouts/without-menu', $controller_path . '\layouts\WithoutMenu@index')->name('layouts-without-menu');
-Route::get('/layouts/without-navbar', $controller_path . '\layouts\WithoutNavbar@index')->name('layouts-without-navbar');
-Route::get('/layouts/fluid', $controller_path . '\layouts\Fluid@index')->name('layouts-fluid');
-Route::get('/layouts/container', $controller_path . '\layouts\Container@index')->name('layouts-container');
-Route::get('/layouts/blank', $controller_path . '\layouts\Blank@index')->name('layouts-blank');
+Route::get('/layouts/without-menu', 'layouts\WithoutMenu@index')->name('layouts-without-menu');
+Route::get('/layouts/without-navbar', 'layouts\WithoutNavbar@index')->name('layouts-without-navbar');
+Route::get('/layouts/fluid', 'layouts\Fluid@index')->name('layouts-fluid');
+Route::get('/layouts/container', 'layouts\Container@index')->name('layouts-container');
+Route::get('/layouts/blank', 'layouts\Blank@index')->name('layouts-blank');
 
 // pages
-Route::get('/pages/account-settings-account', $controller_path . '\pages\AccountSettingsAccount@index')->name('pages-account-settings-account');
-Route::get('/pages/account-settings-notifications', $controller_path . '\pages\AccountSettingsNotifications@index')->name('pages-account-settings-notifications');
-Route::get('/pages/account-settings-connections', $controller_path . '\pages\AccountSettingsConnections@index')->name('pages-account-settings-connections');
-Route::get('/pages/misc-error', $controller_path . '\pages\MiscError@index')->name('pages-misc-error');
-Route::get('/pages/misc-under-maintenance', $controller_path . '\pages\MiscUnderMaintenance@index')->name('pages-misc-under-maintenance');
+Route::get('/pages/account-settings-account', 'pages\AccountSettingsAccount@index')->name('pages-account-settings-account');
+Route::get('/pages/account-settings-notifications', 'pages\AccountSettingsNotifications@index')->name('pages-account-settings-notifications');
+Route::get('/pages/account-settings-connections', 'pages\AccountSettingsConnections@index')->name('pages-account-settings-connections');
+Route::get('/pages/misc-error', 'pages\MiscError@index')->name('pages-misc-error');
+Route::get('/pages/misc-under-maintenance', 'pages\MiscUnderMaintenance@index')->name('pages-misc-under-maintenance');
 
 // authentication
-Route::get('/auth/login-basic', $controller_path . '\authentications\LoginBasic@index')->name('auth-login-basic');
-Route::get('/auth/register-basic', $controller_path . '\authentications\RegisterBasic@index')->name('auth-register-basic');
-Route::get('/auth/forgot-password-basic', $controller_path . '\authentications\ForgotPasswordBasic@index')->name('auth-reset-password-basic');
+Route::get('/auth/login-basic', 'authentications\LoginBasic@index')->name('auth-login-basic');
+Route::get('/auth/register-basic', 'authentications\RegisterBasic@index')->name('auth-register-basic');
+Route::get('/auth/forgot-password-basic', 'authentications\ForgotPasswordBasic@index')->name('auth-reset-password-basic');
 
 // cards
-Route::get('/cards/basic', $controller_path . '\cards\CardBasic@index')->name('cards-basic');
+Route::get('/cards/basic', 'cards\CardBasic@index')->name('cards-basic');
 
 // User Interface
-Route::get('/ui/accordion', $controller_path . '\user_interface\Accordion@index')->name('ui-accordion');
-Route::get('/ui/alerts', $controller_path . '\user_interface\Alerts@index')->name('ui-alerts');
-Route::get('/ui/badges', $controller_path . '\user_interface\Badges@index')->name('ui-badges');
-Route::get('/ui/buttons', $controller_path . '\user_interface\Buttons@index')->name('ui-buttons');
-Route::get('/ui/carousel', $controller_path . '\user_interface\Carousel@index')->name('ui-carousel');
-Route::get('/ui/collapse', $controller_path . '\user_interface\Collapse@index')->name('ui-collapse');
-Route::get('/ui/dropdowns', $controller_path . '\user_interface\Dropdowns@index')->name('ui-dropdowns');
-Route::get('/ui/footer', $controller_path . '\user_interface\Footer@index')->name('ui-footer');
-Route::get('/ui/list-groups', $controller_path . '\user_interface\ListGroups@index')->name('ui-list-groups');
-Route::get('/ui/modals', $controller_path . '\user_interface\Modals@index')->name('ui-modals');
-Route::get('/ui/navbar', $controller_path . '\user_interface\Navbar@index')->name('ui-navbar');
-Route::get('/ui/offcanvas', $controller_path . '\user_interface\Offcanvas@index')->name('ui-offcanvas');
-Route::get('/ui/pagination-breadcrumbs', $controller_path . '\user_interface\PaginationBreadcrumbs@index')->name('ui-pagination-breadcrumbs');
-Route::get('/ui/progress', $controller_path . '\user_interface\Progress@index')->name('ui-progress');
-Route::get('/ui/spinners', $controller_path . '\user_interface\Spinners@index')->name('ui-spinners');
-Route::get('/ui/tabs-pills', $controller_path . '\user_interface\TabsPills@index')->name('ui-tabs-pills');
-Route::get('/ui/toasts', $controller_path . '\user_interface\Toasts@index')->name('ui-toasts');
-Route::get('/ui/tooltips-popovers', $controller_path . '\user_interface\TooltipsPopovers@index')->name('ui-tooltips-popovers');
-Route::get('/ui/typography', $controller_path . '\user_interface\Typography@index')->name('ui-typography');
+Route::get('/ui/accordion', 'user_interface\Accordion@index')->name('ui-accordion');
+Route::get('/ui/alerts', 'user_interface\Alerts@index')->name('ui-alerts');
+Route::get('/ui/badges', 'user_interface\Badges@index')->name('ui-badges');
+Route::get('/ui/buttons', 'user_interface\Buttons@index')->name('ui-buttons');
+Route::get('/ui/carousel', 'user_interface\Carousel@index')->name('ui-carousel');
+Route::get('/ui/collapse', 'user_interface\Collapse@index')->name('ui-collapse');
+Route::get('/ui/dropdowns', 'user_interface\Dropdowns@index')->name('ui-dropdowns');
+Route::get('/ui/footer', 'user_interface\Footer@index')->name('ui-footer');
+Route::get('/ui/list-groups', 'user_interface\ListGroups@index')->name('ui-list-groups');
+Route::get('/ui/modals', 'user_interface\Modals@index')->name('ui-modals');
+Route::get('/ui/navbar', 'user_interface\Navbar@index')->name('ui-navbar');
+Route::get('/ui/offcanvas', 'user_interface\Offcanvas@index')->name('ui-offcanvas');
+Route::get('/ui/pagination-breadcrumbs', 'user_interface\PaginationBreadcrumbs@index')->name('ui-pagination-breadcrumbs');
+Route::get('/ui/progress', 'user_interface\Progress@index')->name('ui-progress');
+Route::get('/ui/spinners', 'user_interface\Spinners@index')->name('ui-spinners');
+Route::get('/ui/tabs-pills', 'user_interface\TabsPills@index')->name('ui-tabs-pills');
+Route::get('/ui/toasts', 'user_interface\Toasts@index')->name('ui-toasts');
+Route::get('/ui/tooltips-popovers', 'user_interface\TooltipsPopovers@index')->name('ui-tooltips-popovers');
+Route::get('/ui/typography', 'user_interface\Typography@index')->name('ui-typography');
 
 // extended ui
-Route::get('/extended/ui-perfect-scrollbar', $controller_path . '\extended_ui\PerfectScrollbar@index')->name('extended-ui-perfect-scrollbar');
-Route::get('/extended/ui-text-divider', $controller_path . '\extended_ui\TextDivider@index')->name('extended-ui-text-divider');
+Route::get('/extended/ui-perfect-scrollbar', 'extended_ui\PerfectScrollbar@index')->name('extended-ui-perfect-scrollbar');
+Route::get('/extended/ui-text-divider', 'extended_ui\TextDivider@index')->name('extended-ui-text-divider');
 
 // icons
-Route::get('/icons/boxicons', $controller_path . '\icons\Boxicons@index')->name('icons-boxicons');
+Route::get('/icons/boxicons', 'icons\Boxicons@index')->name('icons-boxicons');
 
 // form elements
-Route::get('/forms/basic-inputs', $controller_path . '\form_elements\BasicInput@index')->name('forms-basic-inputs');
-Route::get('/forms/input-groups', $controller_path . '\form_elements\InputGroups@index')->name('forms-input-groups');
+Route::get('/forms/basic-inputs', 'form_elements\BasicInput@index')->name('forms-basic-inputs');
+Route::get('/forms/input-groups', 'form_elements\InputGroups@index')->name('forms-input-groups');
 
 // form layouts
-Route::get('/form/layouts-vertical', $controller_path . '\form_layouts\VerticalForm@index')->name('form-layouts-vertical');
-Route::get('/form/layouts-horizontal', $controller_path . '\form_layouts\HorizontalForm@index')->name('form-layouts-horizontal');
+Route::get('/form/layouts-vertical', 'form_layouts\VerticalForm@index')->name('form-layouts-vertical');
+Route::get('/form/layouts-horizontal', 'form_layouts\HorizontalForm@index')->name('form-layouts-horizontal');
 
 // tables
-Route::get('/tables/basic', $controller_path . '\tables\Basic@index')->name('tables-basic');
+Route::get('/tables/basic', 'tables\Basic@index')->name('tables-basic');


### PR DESCRIPTION
This PR improves the controller namespace for the routes, so you don't have to define and repeat your controller namespace for the routes.

**What changed** 
- Set **namespace** controller at `RouteServiceProvider`

```
protected $namespace = 'App\\Http\\Controllers';
```

- Update namespace path for `web` routes

**from**
```
$controller_path = 'App\Http\Controllers';

// Main Page Route
Route::get('/', $controller_path . '\dashboard\Analytics@index')->name('dashboard-analytics');
```

**to**
```
// Main Page Route
Route::get('/', 'dashboard\Analytics@index')->name('dashboard-analytics');
```